### PR TITLE
Update environment.md

### DIFF
--- a/versioned_docs/version-1.9/ui/preferences/application/environment.md
+++ b/versioned_docs/version-1.9/ui/preferences/application/environment.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Environment
-title: Environment
+title: Environment(macOS & Linux)
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
After i install rancher desktop 1.9 in win 11, i can not find the environment under application tab, so i suppose this only shows in Mac or Linux os?

![image](https://github.com/stevenruizhang/docs.rancherdesktop.io/assets/13114985/b85a4363-7828-49d9-bd7b-9cbec3524ebe)
